### PR TITLE
parser: fix empty spans are implemented incorrectly

### DIFF
--- a/packages/macros/Cargo.toml
+++ b/packages/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teleparse-macros"
-version = "0.0.5"
+version = "0.1.0"
 edition = "2021"
 description = "Proc-macro crate for teleparse"
 repository = "https://github.com/Pistonite/teleparse"

--- a/packages/macros/src/lexicon.rs
+++ b/packages/macros/src/lexicon.rs
@@ -141,8 +141,7 @@ pub fn expand(input: &mut syn::DeriveInput) -> syn::Result<TokenStream2> {
                         }
                         infer_literals = None;
                         let doc = format!(
-                            " Terminal symbol derived from [`{}`] with `terminal({})`",
-                            enum_ident, ident
+                            " Terminal symbol derived from [`{enum_ident}`] with `terminal({ident})`",
                         );
                         extra_derives.extend(derive_terminal(
                             terminal_parse,

--- a/packages/teleparse/Cargo.toml
+++ b/packages/teleparse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teleparse"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "teleparse"
 license = "MIT"

--- a/packages/teleparse/Cargo.toml
+++ b/packages/teleparse/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/Pistonite/teleparse"
 authors = ["Pistonight <pistonknight@outlook.com>"]
 
 [dependencies]
-teleparse-macros = { path = "../macros", version = "=0.0.5" }
+teleparse-macros = { path = "../macros", version = "=0.1.0" }
 deref-derive = "0.1.0"
 num = "0.4.3"
 thiserror = "2.0.12"

--- a/packages/teleparse/src/parser/parser_impl.rs
+++ b/packages/teleparse/src/parser/parser_impl.rs
@@ -155,7 +155,7 @@ impl<'s, L: Lexicon> Parser<'s, L> {
         let expecting = FirstSet::one(ty, Some(match_lit));
         if follow.contains(Some(token_src)) {
             // do not consume the next token
-            let token = Token::new(self.current_span_empty(), ty);
+            let token = Token::new(self.empty_span(), ty);
             return SynResult::Recovered(token, vec![self.expecting(expecting)]);
         }
 
@@ -233,10 +233,16 @@ impl<'s, L: Lexicon> Parser<'s, L> {
             .unwrap_or_else(|| self.info.eof())
     }
 
-    /// Get start of the lookahead token as a 0-length span
-    pub fn current_span_empty(&mut self) -> Span {
-        let span = self.current_span();
-        Span::new(span.lo, span.lo)
+    /// Get an empty span representing the current position of the parser,
+    /// which is the lowest span that doesn't overlap with consumed tokens
+    pub fn empty_span(&mut self) -> Span {
+        let hi = self
+            .info
+            .tokens
+            .last()
+            .map(|x| x.span.hi)
+            .unwrap_or_default();
+        Span::new(hi, hi)
     }
 
     pub fn apply_semantic<S: ToSpan>(&mut self, span: &S, semantic: Set<L>) {
@@ -246,72 +252,3 @@ impl<'s, L: Lexicon> Parser<'s, L> {
             .apply_semantic(semantic);
     }
 }
-
-//
-// pub struct ParserIter<'s, 'p, L: Lexicon, R>
-//     {
-//     parser: &'p mut Parser<'s, L>,
-//     metadata: &'static Metadata<L>,
-//         _marker: PhantomData<R>,
-// }
-//
-// impl<'s, 'p, L: Lexicon, R: ParseRoot>  ParserIter<'s, 'p, L, R>
-//     where R::AST : AbstractSyntaxRoot<L=L>
-// {
-//     pub fn new(parser: &'p mut Parser<'s, L>) -> Result<Self, GrammarError> {
-//         let metadata = match R::AST::metadata() {
-//             Ok(meta) => meta,
-//             Err(err) => return Err(err.clone()),
-//         };
-//         Ok(Self {
-//             parser,
-//             metadata,
-//             _marker: PhantomData,
-//         })
-//     }
-// }
-//
-// impl<'s, 'p, L: Lexicon, R: ParseTree> Iterator for ParserIter<'s, 'p, L, R>
-//     where R::AST : AbstractSyntaxTree<L=L>
-// {
-//     type Item = R;
-//
-//     fn next(&mut self) -> Option<Self::Item> {
-//         self.parser.next_root(&self.metadata)
-//     }
-// }
-//
-//
-// pub struct ParseRootIter<'s, L: Lexicon, R>
-//     {
-//     parser: Parser<'s, L>,
-//     metadata: &'static Metadata<L>,
-//         _marker: PhantomData<R>,
-// }
-//
-// impl<'s, L: Lexicon, R: ParseRoot>  ParseRootIter<'s, L, R>
-//     where R::AST : AbstractSyntaxRoot<L=L>
-// {
-//     pub fn new(parser: Parser<'s, L>) -> Result<Self, GrammarError> {
-//         let metadata = match R::AST::metadata() {
-//             Ok(meta) => meta,
-//             Err(err) => return Err(err.clone()),
-//         };
-//         Ok(Self {
-//             parser,
-//             metadata,
-//             _marker: PhantomData,
-//         })
-//     }
-// }
-//
-// impl<'s, L: Lexicon, R: ParseTree> Iterator for ParseRootIter<'s, L, R>
-//     where R::AST : AbstractSyntaxTree<L=L>
-// {
-//     type Item = R;
-//
-//     fn next(&mut self) -> Option<Self::Item> {
-//         self.parser.next_root(&self.metadata)
-//     }
-// }
-//

--- a/packages/teleparse/src/syntax/error.rs
+++ b/packages/teleparse/src/syntax/error.rs
@@ -32,7 +32,7 @@ impl<L: Lexicon> Error<L> {
             },
             ErrorKind::Expecting(set) => {
                 let set = set.as_terminal_set().to_repr().into_iter().join(", ");
-                format!("Expecting one of {}", set)
+                format!("Expecting one of {set}")
             },
             ErrorKind::UnexpectedEof => "Unexpected end of file".to_string(),
             ErrorKind::UnexpectedNoAdvanceInLoop => "Unexpected: Parser did not advance in a loop. The grammar is probably not LL(1), and this is a bug since the parser should catch that before parsing.".to_string(),

--- a/packages/teleparse/src/syntax/lit_set.rs
+++ b/packages/teleparse/src/syntax/lit_set.rs
@@ -18,7 +18,7 @@ pub enum LitSet {
 impl std::fmt::Debug for LitSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Match(set) => write!(f, "{:?}", set),
+            Self::Match(set) => write!(f, "{set:?}"),
             Self::Any => write!(f, "*"),
         }
     }

--- a/packages/teleparse/src/syntax/term_set.rs
+++ b/packages/teleparse/src/syntax/term_set.rs
@@ -48,7 +48,7 @@ impl<L: Lexicon> std::fmt::Debug for TerminalSet<L> {
 impl<L: Lexicon> std::fmt::Display for TerminalSet<L> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let string = self.to_repr().into_iter().join(", ");
-        write!(f, "{{{}}}", string)
+        write!(f, "{{{string}}}")
     }
 }
 
@@ -212,11 +212,11 @@ impl<L: Lexicon> TerminalSet<L> {
             match intersection.iter() {
                 Some(lits) => {
                     for lit in lits {
-                        terminals.insert(format!("\"{}\"", lit));
+                        terminals.insert(format!("\"{lit}\""));
                     }
                 }
                 None => {
-                    terminals.insert(format!("{:?}", ty));
+                    terminals.insert(format!("{ty:?}"));
                 }
             };
         }
@@ -232,11 +232,11 @@ impl<L: Lexicon> TerminalSet<L> {
             match set.iter() {
                 Some(lits) => {
                     for lit in lits {
-                        terminals.insert(format!("\"{}\"", lit));
+                        terminals.insert(format!("\"{lit}\""));
                     }
                 }
                 None => {
-                    terminals.insert(format!("{:?}", ty));
+                    terminals.insert(format!("{ty:?}"));
                 }
             }
         }

--- a/packages/teleparse/src/tp_impl/iter.rs
+++ b/packages/teleparse/src/tp_impl/iter.rs
@@ -149,7 +149,7 @@ impl<T: Produce> Produce for Loop<T> {
         let span = if let (Some(first), Some(last)) = (output.first(), output.last()) {
             Span::new(first.lo(), last.hi())
         } else {
-            parser.current_span_empty()
+            parser.empty_span()
         };
         (Node::new(span, output).into(), errors).into()
     }

--- a/packages/teleparse/src/tp_impl/iter.rs
+++ b/packages/teleparse/src/tp_impl/iter.rs
@@ -320,7 +320,7 @@ mod tests {
     #[test]
     fn parse_single_item_each() {
         let t = ListPlusList::parse("a+ b").unwrap().unwrap();
-        let t_str = format!("{:?}", t);
+        let t_str = format!("{t:?}");
         assert_eq!(t_str, "ListPlusList(0..1 => [token Ident(0..1)], token Op(1..2), 3..4 => [token Ident(3..4)])");
         assert_eq!(t.span(), Span::from(0..4));
         assert_eq!(

--- a/packages/teleparse/src/tp_impl/option.rs
+++ b/packages/teleparse/src/tp_impl/option.rs
@@ -18,10 +18,10 @@ impl<T: Production> Production for OptionProd<T> {
         let inner = T::debug();
         if let Some(rest) = inner.strip_prefix('(') {
             if let Some(inner) = rest.strip_suffix(")+") {
-                return Cow::Owned(format!("({})*", inner));
+                return Cow::Owned(format!("({inner})*"));
             }
             if let Some(inner) = rest.strip_suffix("]+") {
-                return Cow::Owned(format!("({}]*", inner));
+                return Cow::Owned(format!("({inner}]*"));
             }
         }
         Cow::Owned(format!("({})?", T::debug()))

--- a/packages/teleparse/src/tp_impl/recover.rs
+++ b/packages/teleparse/src/tp_impl/recover.rs
@@ -46,13 +46,11 @@ where
                         errors.extend(e);
                         (None, x.span(), Some(x))
                     }
-                    SynResult::Panic(e) => {
-                        (e.into_iter().next_back(), parser.current_span_empty(), None)
-                    }
+                    SynResult::Panic(e) => (e.into_iter().next_back(), parser.empty_span(), None),
                 }
             } else {
                 let e = parser.expecting(head_first.clone());
-                (Some(e), parser.current_span_empty(), None)
+                (Some(e), parser.empty_span(), None)
             };
         let tail_first = meta.first.get(&R::prod_id());
         let tail = loop {


### PR DESCRIPTION
Empty spans at the current position should be returned based on the last consumed token, not from the peeked token. Otherwise, the span of (A, Option<B>) where B is None becomes larger than A if more tokens follow, which is not desirable